### PR TITLE
Turned off white space collapsing functionality

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -18,8 +18,7 @@ module.exports = function(grunt) {
     htmlmin: {
       dist: {
         options: {
-          removeComments: true,
-          collapseWhitespace:true
+          removeComments: true
         },
         files: {
           'out/index.html' : 'out/index.html'


### PR DESCRIPTION
Concerning HTML minification: htmlmin unfortunately doesn't have the option to just strip blank lines in the document, instead it collapses all white spaces generating a problem.

So I first tried to switch from markdown to HTML without space between tags, it didn't work too, because htmlmin also strips white spaces at the beginning and at the end of tags. This is really bad because it really limits htmlmin functionality.

The second thing I tried to do is switch to htmlcompressor, truth is it doesn't work and it's build is failing on travis.

So I decided to stay with htmlmin, but using just the comment removal functionality. So the HTML is not really minified. We can turn off html compression completely if it doesn't offer significant gains in performance as being discussed in #24.
