### PR TITLE
Fixing typo in spanish

### DIFF
--- a/src/documents/server/es/cache.html.md
+++ b/src/documents/server/es/cache.html.md
@@ -21,7 +21,7 @@ ExpiresByType text/javascript "access plus 6 months"
 ExpiresByType application/javascript "access plus 6 months"
 ```
 
-Estas instrucciones cahean las imágenes, CSS y JS durante 6 meses&mdash;es recomendado cachearlas durante al menos un mes. Otros servidors pueden ser configurados de manera similar.
+Estas instrucciones cahean las imágenes, CSS y JS durante 6 meses&mdash;es recomendado cachearlas durante al menos un mes. Otros servidores pueden ser configurados de manera similar.
 
 Una cosa importante para recordar es que una vez cacheado, el navegador no solicitará un archivo nuevo otra vez. Si necesitamos cambiar el contenido del archivo, no funcionará tal y como esperamos, para enviar una nueva versión, necesitamos cambiar el nombre del archivo. Una forma de hacerlo es añadir alguna tipo de versión o fecha al archivo. Por ejemplo, en vez de `home.js` puedes usar `home-v1.js`, y cuando necesitas actualizar el archivo, cambiar el nombre a `home-v2.js`, etc.
 


### PR DESCRIPTION
Fixing typo in spanish translation for "servidors" which really is "servidores".
