### PR TITLE
Remoção da classe .icos-geek em bye.html.md

### DIFF
--- a/src/documents/bonus/zh/bye.html.md
+++ b/src/documents/bonus/zh/bye.html.md
@@ -4,7 +4,7 @@ title: That's it for today!
 ---
 
 <div class="img-right">
-  <img id="geek-31" class="icos-geek" src="http://browserdiet.com/img/31.png" alt="Geek #31" width="162" height="275" />
+  <img id="geek-31" src="http://browserdiet.com/img/31.png" alt="Geek #31" width="162" height="275" />
 </div>
 
 我们希望，在阅读了这篇指南之后，你就能够对你的网站进行瘦身了。:)


### PR DESCRIPTION
A classe .icos-geek não só se mostra desnecessária como atrapalha a navegação na página do BrowserDiet. Na versão brasileira do projeto a classe não é utilizada na imagem Geek #31 e ainda assim o website funciona perfeitamente.

Além disso, a classe aplica regras CSS que impedem o funcionamento do botão "Edit" nessa seção, já que imagem Geek #31 fica sobreposta ao ícone.

O mesmo ocorre nas demais traduções, com exceção da versão brasileira, onde não há a classe.
