### PR TITLE
Update DOM Manipulations, include DOM Fragments

### DIFF
--- a/src/documents/js/pt/dont-touch-dom.html.md
+++ b/src/documents/js/pt/dont-touch-dom.html.md
@@ -37,3 +37,20 @@ for (var i = 0; i < 100; i++) {
 ```
 
 *> [Resultados no JSPerf](http://jsperf.com/browser-diet-dom-manipulation/11)*
+
+```js
+Porém, precisamos considerar o item anterior, onde é muito importante minimizar repaints e reflows, portanto se você estiver trabalhando com uma carga muito grande de elementos que precisam ser atualizados, talvez seja melhor você considerar usar `document.documentCreateFragment`, onde os elementos são armazenados em um array, e incluídos de uma vez só no DOM.
+
+var myListHTML = document.getElementById("myList"), newHTML, fragments = document.createDocumentFragment();
+
+for (var i = 0; i < 100; i++) {
+  newHTML = document.createElement('span');
+  newHTML.innerText = i;
+
+  fragments.appendChild(newHTML);
+}
+
+myListHTML.appendChild(fragments);
+```
+
+*> [Referências](https://github.com/zenorocha/browser-diet/wiki/References#avoid-unnecessary-dom-manipulations)*


### PR DESCRIPTION
I've created a reference to DOM Fragments, it may seem slower than the other references, but when we are talking about a lot of elements it's faster, since it only touches the DOM once.

You may change the text (I'm not a good writer) if you agree that's a good reference for Browser Diet.