### PR TITLE
Fix GitHub Ribbon

### DIFF
--- a/src/documents/assets/css/i18n.less
+++ b/src/documents/assets/css/i18n.less
@@ -10,3 +10,12 @@
 
 .es .intro h1 span { font-size: 3.1em; }
 .es .subtitle h3 { margin-left: -15px; }
+
+.mq-gh-ribbon(~'.en', ~'@{gh-ribbon}', ~'645px');
+.mq-gh-ribbon(~'.pt', ~'@{gh-ribbon}', ~'645px');
+.mq-gh-ribbon(~'.es', ~'@{gh-ribbon}', ~'670px');
+.mq-gh-ribbon(~'.pl', ~'@{gh-ribbon}', ~'710px');
+.mq-gh-ribbon(~'.zh', ~'@{gh-ribbon}', ~'565px');
+.mq-gh-ribbon(~'.cs', ~'@{gh-ribbon}', ~'565px');
+.mq-gh-ribbon(~'.fr', ~'@{gh-ribbon}', ~'665px');
+.mq-gh-ribbon(~'.jp', ~'@{gh-ribbon}', ~'630px');

--- a/src/documents/assets/css/i18n.less
+++ b/src/documents/assets/css/i18n.less
@@ -6,10 +6,22 @@
 
 .pl .intro h1 { font-size: 3.7em; }
 .pl .intro h1 span { font-size: 2.3em; }
-.pl .subtitle h3 { font-size: 1.2em; margin-left: -85px; }
+.pl .subtitle h3 {
+  font-size: 1.2em;
+  padding: .5em 0;
+  @media (max-width: 592px) {
+    font-size: .75em;
+    padding: 1.2em 0;
+  }
+}
 
 .es .intro h1 span { font-size: 3.1em; }
-.es .subtitle h3 { margin-left: -15px; }
+.es .subtitle h3 {
+  @media (max-width: 555px) {
+    font-size: .95em;
+    padding: .8em 0;
+  }
+}
 
 .mq-gh-ribbon(~'.en', ~'@{gh-ribbon}', ~'645px');
 .mq-gh-ribbon(~'.pt', ~'@{gh-ribbon}', ~'645px');

--- a/src/documents/assets/css/style.less
+++ b/src/documents/assets/css/style.less
@@ -161,6 +161,7 @@ strong {
 
 	@media (max-width: 550px) {
 		font-size: 0.95em;
+    padding: .8em 0;
 	}
 }
 

--- a/src/documents/assets/css/style.less
+++ b/src/documents/assets/css/style.less
@@ -159,10 +159,10 @@ strong {
 	font-family: 'Open Sans', sans-serif;
 	font-weight: normal;
 
-	@media (max-width: 550px) {
-		font-size: 0.95em;
+  @media (max-width: 550px) {
+    font-size: 0.95em;
     padding: .8em 0;
-	}
+  }
 }
 
 .intro {

--- a/src/documents/assets/css/style.less
+++ b/src/documents/assets/css/style.less
@@ -1,8 +1,17 @@
+/* --- Mixins --- */
+
+.mq-gh-ribbon(@lang, @selector, @width) {
+  @media (max-width: @width) {
+    @{lang} @{selector} { display: none; }
+  }
+}
+
 /* --- Vars --- */
 
 @yellow: #FFDE00;
 @red: #E60014;
 @orange: #FFBF00;
+@gh-ribbon: ~'img[alt="Fork me on GitHub"]';
 
 /* --- Reset --- */
 
@@ -132,18 +141,9 @@ strong {
 
 /*	--- Header --- */
 
-#github-ribbon {
-	position: fixed;
-	top: 0;
-	right: 0;
-	border: 0;
-	z-index: 2;
+@{gh-ribbon} {
+  z-index: 2;
 }
-
-	// Remove ribbon from small view
-	@media (max-width: 1260px) {
-		#github-ribbon { display: none; }
-	}
 
 .subtitle h3 {
   text-align: left;


### PR DESCRIPTION
Em telas menores o GitHub Ribbon está ficando atrás do conteúdo de destaque principal `div.intro`.

![screenshot_2015-03-26-14-55-49](https://cloud.githubusercontent.com/assets/174275/6859263/b3c28a40-d3f5-11e4-9ce4-83f1789db2ba.jpg)
