### PR TITLE
Adjusting links - Acertando os links do PageSpeed

### DIFF
--- a/docpad.coffee
+++ b/docpad.coffee
@@ -11,7 +11,7 @@ module.exports =
         # Language Definition
 
         lang: require('./i18n')
-        currentLang: 'en'
+        currentLang: 'pt'
 
         # -----------------------------
         # Site Information

--- a/docpad.coffee
+++ b/docpad.coffee
@@ -11,7 +11,7 @@ module.exports =
         # Language Definition
 
         lang: require('./i18n')
-        currentLang: 'pt'
+        currentLang: 'en'
 
         # -----------------------------
         # Site Information

--- a/src/documents/bonus/cs/tools.html.md
+++ b/src/documents/bonus/cs/tools.html.md
@@ -7,8 +7,8 @@ title: Diagnostické nástroje: váš nejlepší přítel
   <img id="geek-43" class="icos-geek" src="http://browserdiet.com/en/assets/img/43.png" alt="Geek #43" width="157" height="275" />
 </div>
 
-Pokud chcete proniknout do světa optimalizací výkonu webu, je zásadní nainstalovat si [YSlow](http://yslow.org/) a [PageSpeed](https://developers.google.com/speed/pagespeed/insights_extensions) rozšíření do prohlížeče&mdash;to budou od teď vaši nejlepší přátelé.
+Pokud chcete proniknout do světa optimalizací výkonu webu, je zásadní nainstalovat si [YSlow](http://yslow.org/) rozšíření do prohlížeče&mdash;to budou od teď vaši nejlepší přátelé.
 
-Pokud preferujete online nástroje, navštivte [WebPageTest](http://www.webpagetest.org/), [HTTP Archive](http://httparchive.org/), nebo [PageSpeed](http://pagespeed.googlelabs.com/).
+Pokud preferujete online nástroje, navštivte [WebPageTest](http://www.webpagetest.org/), [HTTP Archive](http://httparchive.org/), nebo [PageSpeed](https://developers.google.com/speed/pagespeed/insights/).
 
 V zásadě každý nástroj analyzuje výkon stránky a vytvoří report, který stránku ohodnotí a přidá neocenitelné rady, které pomohou vyřešit případné problémy.

--- a/src/documents/bonus/en/tools.html.md
+++ b/src/documents/bonus/en/tools.html.md
@@ -7,8 +7,8 @@ title: Diagnosis tools: your best friend
   <img id="geek-43" class="icos-geek" src="http://browserdiet.com/en/assets/img/43.png" alt="Geek #43" width="157" height="275" />
 </div>
 
-If you'd like to venture into this world of web performance, it's crucial to install the [YSlow](http://yslow.org/) and [PageSpeed](https://developers.google.com/speed/pagespeed/insights_extensions) extensions in your browser&mdash;they'll be your best friends from now on.
+If you'd like to venture into this world of web performance, it's crucial to install the [YSlow](http://yslow.org/) extension in your browser&mdash;they'll be your best friends from now on.
 
-Or, if you prefer online tools, visit the [WebPageTest](http://www.webpagetest.org/), [HTTP Archive](http://httparchive.org/), or [PageSpeed](http://pagespeed.googlelabs.com/) sites.
+Or, if you prefer online tools, visit the [WebPageTest](http://www.webpagetest.org/), [HTTP Archive](http://httparchive.org/), or [PageSpeed](https://developers.google.com/speed/pagespeed/insights/) sites.
 
 In general each will analyse your site's performance and create a report that gives your site a grade coupled with invaluable advice to help you resolve the potential problems.

--- a/src/documents/bonus/es/tools.html.md
+++ b/src/documents/bonus/es/tools.html.md
@@ -7,8 +7,8 @@ title: Herramientas de diagnóstico: tus mejores amigas
   <img id="geek-43" src="http://browserdiet.com/en/assets/img/43.png" alt="Geek #43" width="157" height="275" />
 </div>
 
-Si quieres aventurarte en este mundo, es imprescindible insalar las extensiones [YSlow](http://yslow.org/) y [PageSpeed](https://developers.google.com/speed/pagespeed/insights_extensions) en tu navegador *Chrome* o *Firefox*. Ellas serán tus mejores amigas a partir de ese momento.
+Si quieres aventurarte en este mundo, es imprescindible insalar la extension [YSlow](http://yslow.org/) en tu navegador *Chrome* o *Firefox*. Ellas serán tus mejores amigas a partir de ese momento.
 
-O si prefieres herramientas online, visite [WebPageTest](http://www.webpagetest.org/), [HTTP Archive](http://httparchive.org/) o [PageSpeed](http://pagespeed.googlelabs.com/) (sitio).
+O si prefieres herramientas online, visite [WebPageTest](http://www.webpagetest.org/), [HTTP Archive](http://httparchive.org/) o [PageSpeed](https://developers.google.com/speed/pagespeed/insights/).
 
 En general analizan el rendimiento de tu sitio, y generan un informe que califica a tu sitio con una nota además de darte consejos invaluables para ayudarte a resolver los problemas potenciales.

--- a/src/documents/bonus/fr/tools.html.md
+++ b/src/documents/bonus/fr/tools.html.md
@@ -7,8 +7,8 @@ title: Outils de diagnostic: votre meilleur ami
   <img id="geek-43" class="icos-geek" src="http://browserdiet.com/en/assets/img/43.png" alt="Geek #43" width="157" height="275" />
 </div>
 
-Si vous voulez vous aventurer dans le monde des perfomances web, il est crucial d'installer les extensions [YSlow](http://yslow.org/) et [PageSpeed](https://developers.google.com/speed/pagespeed/insights_extensions) dans votre navigateur&mdash;ils seront vos meilleurs amis à partir de maintenant.
+Si vous voulez vous aventurer dans le monde des perfomances web, il est crucial d'installer le extension [YSlow](http://yslow.org/) dans votre navigateur&mdash;ils seront vos meilleurs amis à partir de maintenant.
 
-Ou bien, si vous préférez les outils en ligne, visitez les sites [WebPageTest](http://www.webpagetest.org/), [HTTP Archive](http://httparchive.org/), ou [PageSpeed](http://pagespeed.googlelabs.com/).
+Ou bien, si vous préférez les outils en ligne, visitez les sites [WebPageTest](http://www.webpagetest.org/), [HTTP Archive](http://httparchive.org/), ou [PageSpeed](https://developers.google.com/speed/pagespeed/insights/).
 
 D'une manière générale, chacun analysera les performances de votre site et créera un rapport qui vous donnera une note couplée avec de précieux conseils pour vous aider à résoudre les problèmes potentiels.

--- a/src/documents/bonus/jp/tools.html.md
+++ b/src/documents/bonus/jp/tools.html.md
@@ -7,9 +7,9 @@ title: 診断ツール: あなたの親友
   <img id="geek-43" class="icos-geek" src="http://browserdiet.com/en/assets/img/43.png" alt="Geek #43" width="157" height="275" />
 </div>
 
-あなたがウェブパフォーマンスの世界に挑もうと思うのであれば、ブラウザに[YSlow](http://yslow.org/)と[PageSpeed](https://developers.google.com/speed/pagespeed/insights_extensions)の拡張機能をインストールすることは極めて重要です&mdash;その瞬間から彼らはあなたの親友となります。
+あなたがウェブパフォーマンスの世界に挑もうと思うのであれば、ブラウザに[YSlow](http://yslow.org/) の拡張機能をインストールすることは極めて重要です&mdash;その瞬間から彼らはあなたの親友となります。
 
 
-それか、オンラインツールを希望するのであれば、[WebPageTest](http://www.webpagetest.org/)、[HTTP Archive](http://httparchive.org/)か[PageSpeed](http://pagespeed.googlelabs.com/)のサイトを訪れてください。
+それか、オンラインツールを希望するのであれば、[WebPageTest](http://www.webpagetest.org/)、[HTTP Archive](http://httparchive.org/)か[PageSpeed](https://developers.google.com/speed/pagespeed/insights/)のサイトを訪れてください。
 
 一般的にそれらはあなたのサイトのパフォーマンスを解析し、あなたのサイトに対する滞在的な問題を解決して助けてくれる非常に貴重なアドバイスを伴った成績のレポートを作成してくれます。

--- a/src/documents/bonus/pl/tools.html.md
+++ b/src/documents/bonus/pl/tools.html.md
@@ -7,8 +7,8 @@ title: Narzędzia diagnostyczne: twój najlepszy przyjaciel
   <img id="geek-43" class="icos-geek" src="http://browserdiet.com/en/assets/img/43.png" alt="Geek #43" width="157" height="275" />
 </div>
 
-Jeśli chcesz dołączyć do świata wydajności internetowej, kluczowe będzie zainstalowanie wtyczek [YSlow](http://yslow.org/) i [PageSpeed](https://developers.google.com/speed/pagespeed/insights_extensions) w twojej przeglądarce&mdash;od teraz będą twoimi najlepszymi przyjaciółmi.
+Jeśli chcesz dołączyć do świata wydajności internetowej, kluczowe będzie zainstalowanie wtyczek [YSlow](http://yslow.org/) w twojej przeglądarce&mdash;od teraz będą twoimi najlepszymi przyjaciółmi.
 
-Albo, jeśli wolisz narzędzia online, odwiedź strony [WebPageTest](http://www.webpagetest.org/), [HTTP Archive](http://httparchive.org/) lub [PageSpeed](http://pagespeed.googlelabs.com/).
+Albo, jeśli wolisz narzędzia online, odwiedź strony [WebPageTest](http://www.webpagetest.org/), [HTTP Archive](http://httparchive.org/) lub [PageSpeed](https://developers.google.com/speed/pagespeed/insights/).
 
 W zasadzie każde z nich po analizie wydajności twojej strony stworzy raport, który połączony z bezcennymi radami pomoże w rozwiązaniu ewentualnych problemów.

--- a/src/documents/bonus/pt/tools.html.md
+++ b/src/documents/bonus/pt/tools.html.md
@@ -7,8 +7,8 @@ title: Ferramentas de diagnóstico: suas melhores amigas
   <img id="geek-43" src="http://browserdiet.com/en/assets/img/43.png" alt="Geek #43" width="157" height="275" />
 </div>
 
-Se você quer se aventurar nesse mundo, é imprescindível instalar as extensões [YSlow](http://yslow.org/) e [PageSpeed](https://developers.google.com/speed/pagespeed/insights_extensions) no seu *Chrome* ou *Firefox*, elas serão suas melhores amigas a partir desse momento.
+Se você quer se aventurar nesse mundo, é imprescindível instalar a extensão [YSlow](http://yslow.org/) no seu *Chrome* ou *Firefox*, elas serão suas melhores amigas a partir desse momento.
 
-Ou se preferir ferramentas online, visite o [WebPageTest](http://www.webpagetest.org/), [HTTP Archive](http://httparchive.org/) ou [PageSpeed](http://pagespeed.googlelabs.com/) (site).
+Ou se preferir ferramentas online, visite o [WebPageTest](http://www.webpagetest.org/), [HTTP Archive](http://httparchive.org/) ou [PageSpeed](https://developers.google.com/speed/pagespeed/insights/).
 
 Em geral elas analisam a performance do seu site, geram um relatório e dão uma nota para ele, sem contar nas dicas preciosas que apresentam para você resolver cada um dos problemas.

--- a/src/documents/bonus/zh/tools.html.md
+++ b/src/documents/bonus/zh/tools.html.md
@@ -7,8 +7,8 @@ title: 诊断工具：你最好的朋友
   <img id="geek-43" class="icos-geek" src="http://browserdiet.com/en/assets/img/43.png" alt="Geek #43" width="157" height="275" />
 </div>
 
-如果你想知道这个世界上的Web性能，那么你一定要给你的浏览器安装[YSlow](http://yslow.org/)和 [PageSpeed](https://developers.google.com/speed/pagespeed/insights_extensions)&mdash;从现在起，它们将是你最好的朋友。
+如果你想知道这个世界上的Web性能，那么你一定要给你的浏览器安装[YSlow](http://yslow.org/) 从现在起，它们将是你最好的朋友。
 
-或者你可以选择使用在线工具，访问[WebPageTest](http://www.webpagetest.org/), [HTTP Archive](http://httparchive.org/)或者[PageSpeed](http://pagespeed.googlelabs.com/)。
+或者你可以选择使用在线工具，访问[WebPageTest](http://www.webpagetest.org/), [HTTP Archive](http://httparchive.org/)或者[PageSpeed](https://developers.google.com/speed/pagespeed/insights/)。
 
 不管是哪种方式，都可以对你的网站的性能进行分析，并且给出分析报告，还可以对潜在的问题给出建议。


### PR DESCRIPTION
Não existe mais a extensão do PageSpeed pra chrome e firefox (pelo menos não oficialmente pelo google), além disto, o link para ela mudou, portanto  a seção bônus - ferramentas ficou depreciada. Corrigi esse link em pt e nos demais idiomas (na medida do possível e do meu conhecimento).

Enjoy ;)