### PR TITLE
Fixes build on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ If you want to add new tips or edit the existing ones, just go to the [src/docum
 5. Install all dependencies:
 
   ```sh
-  $ docpad install
+  $ npm install
   ```
 
 6. And finally run:

--- a/docpad.coffee
+++ b/docpad.coffee
@@ -19,27 +19,6 @@ module.exports =
         site:
             assets: 'http://zenorocha.github.io/browser-diet/assets'
 
-        getGruntedStyles: ->
-            _ = require 'underscore'
-            styles = []
-            gruntConfig = require('./Gruntfile.js')
-            _.each gruntConfig, (value, key) ->
-                styles = styles.concat _.flatten _.pluck value, 'dest'
-            styles = _.filter styles, (value) ->
-                return value.indexOf('.min.css') > -1
-            _.map styles, (value) ->
-                return value.replace 'out', ''
-
-        getGruntedScripts: ->
-            _ = require 'underscore'
-            scripts = []
-            gruntConfig = require('./Gruntfile.js')
-            _.each gruntConfig, (value, key) ->
-                scripts = scripts.concat _.flatten _.pluck value, 'dest'
-            scripts = _.filter scripts, (value) ->
-                return value.indexOf('.min.js') > -1
-            _.map scripts, (value) ->
-                return value.replace 'out', ''
 
         getLang: ->
             currentLang = @currentLang.toString()
@@ -56,32 +35,8 @@ module.exports =
                     assets: 'http://localhost:9778/assets'
 
     # =================================
-    # DocPad Events
+    # DocPad Grunt Plugin
 
-    events:
-
-        # Write After
-        # Used to minify our assets with grunt
-        writeAfter: (opts,next) ->
-            # Prepare
-            docpad = @docpad
-            rootPath = docpad.config.rootPath
-            balUtil = require 'bal-util'
-            _ = require 'underscore'
-
-            # Make sure to register a grunt `default` task
-            command = ["#{rootPath}/node_modules/.bin/grunt", 'default']
-
-            # Execute
-            balUtil.spawn command, {cwd:rootPath,output:true}, ->
-                src = []
-                gruntConfig = require './Gruntfile.js'
-                _.each gruntConfig, (value, key) ->
-                    src = src.concat _.flatten _.pluck value, 'src'
-                _.each src, (value) ->
-                    balUtil.spawn ['rm', value], {cwd:rootPath, output:false}, ->
-                balUtil.spawn ['find', '.', '-type', 'd', '-empty', '-exec', 'rmdir', '{}', '\;'], {cwd:rootPath+'/out', output:false}, ->
-                next()
-
-            # Chain
-            @
+    plugins:
+        grunt:
+            writeAfter: ['cssmin']

--- a/package.json
+++ b/package.json
@@ -1,19 +1,16 @@
 {
   "private": true,
   "dependencies": {
-    "bal-util": "~1.15.3",
     "docpad": "6.78.4",
     "docpad-plugin-eco": "~2.1.0",
     "docpad-plugin-highlightjs": "~2.3.0",
     "docpad-plugin-less": "~2.4.1",
     "docpad-plugin-marked": "~2.3.0",
-    "docpad-plugin-partials": "~2.9.2",
-    "underscore": "~1.4.3"
+    "docpad-plugin-partials": "~2.9.2"
   },
   "devDependencies": {
-    "grunt": "~0.4.0",
-    "grunt-cli": "0.1.13",
-    "grunt-contrib-cssmin": "~0.10.0"
+    "docpad-plugin-grunt": "~2.2.0",
+    "grunt-contrib-cssmin": "~0.14.0"
   },
   "scripts": {
     "test": "docpad generate"


### PR DESCRIPTION
As we discussed in #282 we currently have a problem when building the project on Windows.

The fact is the way we are handling grunt currently breaks on Windows. So this PR suggests a change in favor of the docpad `grunt` plugin.

The change also simplifies a bunch of the code in `docpad.coffee` and remove some now unused dependencies.

Tests have been made on both Windows and Mac (Unix) and it works fine.

The second commit is optional but I think it's better to replace the `docpad install` command for a simple `npm install` one because npm have shown to be more stable across platforms.

For example: In Windows XP I ran across an error when running `docpad install`, yet everything works fine when running `npm install`. It seems like this is [an issue](https://github.com/docpad/docpad/issues/595) not completely solved by the guys developing `docpad` or they just dropped support for XP, which is fair enough.

Anyways, as usual, please review the PR and let me know if I need to change anything.

**BTW:** I've tried to switch grunt for gulp but for our case specifically I couldn't see any performance gain. They have pretty much the same speed when running the `cssmin` task.