### PR TITLE
use overflow auto for pre code block

### DIFF
--- a/src/documents/assets/css/syntax-highlight.less
+++ b/src/documents/assets/css/syntax-highlight.less
@@ -13,7 +13,7 @@ pre code {
   padding: 0.5em;
   color: #333;
   background: #f8f8ff;
-  overflow: hidden;
+  overflow: auto;
   -webkit-box-sizing: border-box;
      -moz-box-sizing: border-box;
           box-sizing: border-box;


### PR DESCRIPTION
Currently, you can't scroll the code in a mobile view, this PR enable overflow scroll if the content is clipped:

overflow: hidden  |  overflow: auto;
:-------------------------:|:-------------------------:
![screen shot 2018-10-12 at 14 26 53](https://user-images.githubusercontent.com/10618352/46884292-f807a900-ce2a-11e8-81dc-1847a6008102.png)  |  ![screen shot 2018-10-12 at 14 27 11](https://user-images.githubusercontent.com/10618352/46884449-651b3e80-ce2b-11e8-8337-4b8d3e6982d4.png)