### PR TITLE
url incorreta

### DIFF
--- a/src/documents/jquery/pt/latest-version.html.md
+++ b/src/documents/jquery/pt/latest-version.html.md
@@ -12,7 +12,7 @@ Os membros do core do jQuery estão sempre buscando trazer novidades para a bibl
 Por isso use sempre a última versão do jQuery, que está sempre disponível aqui, caso você queira copiar para um arquivo local:
 
 ```html
-http://code.jquery.com/jquery-latest.js
+https://jquery.com/download/
 ```
 
 Mas _nunca_ referencie essa URL em uma tag `<script>`: isso pode criar problemas no futuro, já que novas versões são automaticamente servidas no seu site antes mesmo de você ter a chance de testá-las. Em vez disso, use a última versão específica do jQuery que você precisa.


### PR DESCRIPTION
a url `http://code.jquery.com/jquery-latest.js` aponta para a versão 1.11.1 e não para a versão mais recente. a utilização dessa url [já foi desaconselhada em 2014](http://blog.jquery.com/2014/07/03/dont-use-jquery-latest-js/), por vários motivos [recomenda-se que a versão MAJOR seja sempre explicitada na url](https://stackoverflow.com/questions/441412/is-there-a-link-to-the-latest-jquery-library-on-google-apis).